### PR TITLE
Fixed gamepad support

### DIFF
--- a/objects/obj_persistent.object.gmx
+++ b/objects/obj_persistent.object.gmx
@@ -90,6 +90,111 @@ math_set_epsilon(0.00001)
 
 //Disable application surface automatic drawing
 application_surface_draw_enable(0)
+
+//Handle gamepad support
+alarm[6] = 240
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="2" enumb="7">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Gamepad support
+
+//Up button
+if gamepad_button_check_pressed(0,gp_padu)
+    keyboard_key_press(vk_up)
+else if gamepad_button_check_released(0,gp_padu)
+    keyboard_key_release(vk_up)
+
+//Down button
+if gamepad_button_check_pressed(0,gp_padd)
+    keyboard_key_press(vk_down)
+else if gamepad_button_check_released(0,gp_padd)
+    keyboard_key_release(vk_down)
+
+//Left button
+if gamepad_button_check_pressed(0,gp_padl)
+    keyboard_key_press(vk_left)
+else if gamepad_button_check_released(0,gp_padl)
+    keyboard_key_release(vk_left)
+
+//Right button
+if gamepad_button_check_pressed(0,gp_padr)
+    keyboard_key_press(vk_right)
+else if gamepad_button_check_released(0,gp_padr)
+    keyboard_key_release(vk_right)
+
+//A button
+if gamepad_button_check_pressed(0,gp_face1)
+    keyboard_key_press(vk_shift)
+else if gamepad_button_check_released(0,gp_face1)
+    keyboard_key_release(vk_shift)
+
+//B/X button
+if (gamepad_button_check_pressed(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+or (gamepad_button_check_pressed(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_press(vk_control)
+else if (gamepad_button_check_released(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+     or (gamepad_button_check_released(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_release(vk_control)
+
+//Start button
+if gamepad_button_check_pressed(0,gp_start)
+    keyboard_key_press(vk_enter)
+else if gamepad_button_check_released(0,gp_start)
+    keyboard_key_release(vk_enter)
+
+//Select button
+if gamepad_button_check_pressed(0,gp_select)
+    keyboard_key_press(vk_space)
+else if gamepad_button_check_released(0,gp_select)
+    keyboard_key_release(vk_space)
+
+//Continue
+alarm[7] = 1
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="2" enumb="6">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Gamepad check
+
+if gamepad_is_connected(0)
+    alarm[7] = 1
 </string>
           </argument>
         </arguments>
@@ -142,6 +247,7 @@ event_user(1)
           <argument>
             <kind>1</kind>
             <string>///Go to the title screen
+
 room_goto(rm_title)
 </string>
           </argument>
@@ -263,82 +369,6 @@ if not instance_exists(obj_mariostart)
 //Delete the screenshot
 if background_exists(back)
     background_delete(back)
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
-    <event eventtype="3" enumb="0">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>///Gamepad support
-
-if gamepad_is_connected(0)
-{
-//Up button
-if gamepad_button_check_pressed(0,gp_padu)
-    keyboard_key_press(vk_up)
-else if gamepad_button_check_released(0,gp_padu)
-    keyboard_key_release(vk_up)
-
-//Down button
-if gamepad_button_check_pressed(0,gp_padd)
-    keyboard_key_press(vk_down)
-else if gamepad_button_check_released(0,gp_padd)
-    keyboard_key_release(vk_down)
-
-//Left button
-if gamepad_button_check_pressed(0,gp_padl)
-    keyboard_key_press(vk_left)
-else if gamepad_button_check_released(0,gp_padl)
-    keyboard_key_release(vk_left)
-
-//Right button
-if gamepad_button_check_pressed(0,gp_padr)
-    keyboard_key_press(vk_right)
-else if gamepad_button_check_released(0,gp_padr)
-    keyboard_key_release(vk_right)
-
-//A button
-if gamepad_button_check_pressed(0,gp_face1)
-    keyboard_key_press(vk_shift)
-else if gamepad_button_check_released(0,gp_face1)
-    keyboard_key_release(vk_shift)
-
-//B/Y button
-if (gamepad_button_check_pressed(0,gp_face2) and not gamepad_button_check(0,gp_face3))
-or (gamepad_button_check_pressed(0,gp_face3) and not gamepad_button_check(0,gp_face2))
-    keyboard_key_press(vk_control)
-else if (gamepad_button_check_released(0,gp_face2) and not gamepad_button_check(0,gp_face3))
-     or (gamepad_button_check_released(0,gp_face3) and not gamepad_button_check(0,gp_face2))
-    keyboard_key_release(vk_control)
-
-//Start button
-if gamepad_button_check_pressed(0,gp_start)
-    keyboard_key_press(vk_enter)
-else if gamepad_button_check_released(0,gp_start)
-    keyboard_key_release(vk_enter)
-
-//Select button
-if gamepad_button_check_pressed(0,gp_select)
-    keyboard_key_press(vk_space)
-else if gamepad_button_check_released(0,gp_select)
-    keyboard_key_release(vk_space)
-}
 </string>
           </argument>
         </arguments>

--- a/objects/obj_persistent.object.gmx
+++ b/objects/obj_persistent.object.gmx
@@ -92,109 +92,7 @@ math_set_epsilon(0.00001)
 application_surface_draw_enable(0)
 
 //Handle gamepad support
-alarm[6] = 240
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
-    <event eventtype="2" enumb="7">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>///Gamepad support
-
-//Up button
-if gamepad_button_check_pressed(0,gp_padu)
-    keyboard_key_press(vk_up)
-else if gamepad_button_check_released(0,gp_padu)
-    keyboard_key_release(vk_up)
-
-//Down button
-if gamepad_button_check_pressed(0,gp_padd)
-    keyboard_key_press(vk_down)
-else if gamepad_button_check_released(0,gp_padd)
-    keyboard_key_release(vk_down)
-
-//Left button
-if gamepad_button_check_pressed(0,gp_padl)
-    keyboard_key_press(vk_left)
-else if gamepad_button_check_released(0,gp_padl)
-    keyboard_key_release(vk_left)
-
-//Right button
-if gamepad_button_check_pressed(0,gp_padr)
-    keyboard_key_press(vk_right)
-else if gamepad_button_check_released(0,gp_padr)
-    keyboard_key_release(vk_right)
-
-//A button
-if gamepad_button_check_pressed(0,gp_face1)
-    keyboard_key_press(vk_shift)
-else if gamepad_button_check_released(0,gp_face1)
-    keyboard_key_release(vk_shift)
-
-//B/X button
-if (gamepad_button_check_pressed(0,gp_face2) and not gamepad_button_check(0,gp_face3))
-or (gamepad_button_check_pressed(0,gp_face3) and not gamepad_button_check(0,gp_face2))
-    keyboard_key_press(vk_control)
-else if (gamepad_button_check_released(0,gp_face2) and not gamepad_button_check(0,gp_face3))
-     or (gamepad_button_check_released(0,gp_face3) and not gamepad_button_check(0,gp_face2))
-    keyboard_key_release(vk_control)
-
-//Start button
-if gamepad_button_check_pressed(0,gp_start)
-    keyboard_key_press(vk_enter)
-else if gamepad_button_check_released(0,gp_start)
-    keyboard_key_release(vk_enter)
-
-//Select button
-if gamepad_button_check_pressed(0,gp_select)
-    keyboard_key_press(vk_space)
-else if gamepad_button_check_released(0,gp_select)
-    keyboard_key_release(vk_space)
-
-//Continue
-alarm[7] = 1
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
-    <event eventtype="2" enumb="6">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>///Gamepad check
-
-if gamepad_is_connected(0)
-    alarm[7] = 1
+gamepad=gamepad_is_connected(0)
 </string>
           </argument>
         </arguments>
@@ -369,6 +267,84 @@ if not instance_exists(obj_mariostart)
 //Delete the screenshot
 if background_exists(back)
     background_delete(back)
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="3" enumb="0">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Gamepad support
+
+//See if a gamepad is connected (in the Create event)
+if gamepad
+{
+//Up button
+if gamepad_button_check_pressed(0,gp_padu)
+    keyboard_key_press(vk_up)
+else if gamepad_button_check_released(0,gp_padu)
+    keyboard_key_release(vk_up)
+
+//Down button
+if gamepad_button_check_pressed(0,gp_padd)
+    keyboard_key_press(vk_down)
+else if gamepad_button_check_released(0,gp_padd)
+    keyboard_key_release(vk_down)
+
+//Left button
+if gamepad_button_check_pressed(0,gp_padl)
+    keyboard_key_press(vk_left)
+else if gamepad_button_check_released(0,gp_padl)
+    keyboard_key_release(vk_left)
+
+//Right button
+if gamepad_button_check_pressed(0,gp_padr)
+    keyboard_key_press(vk_right)
+else if gamepad_button_check_released(0,gp_padr)
+    keyboard_key_release(vk_right)
+
+//A button
+if gamepad_button_check_pressed(0,gp_face1)
+    keyboard_key_press(vk_shift)
+else if gamepad_button_check_released(0,gp_face1)
+    keyboard_key_release(vk_shift)
+
+//B/X button
+if (gamepad_button_check_pressed(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+or (gamepad_button_check_pressed(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_press(vk_control)
+else if (gamepad_button_check_released(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+     or (gamepad_button_check_released(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_release(vk_control)
+
+//Start button
+if gamepad_button_check_pressed(0,gp_start)
+    keyboard_key_press(vk_enter)
+else if gamepad_button_check_released(0,gp_start)
+    keyboard_key_release(vk_enter)
+
+//Select button
+if gamepad_button_check_pressed(0,gp_select)
+    keyboard_key_press(vk_space)
+else if gamepad_button_check_released(0,gp_select)
+    keyboard_key_release(vk_space)
+
+}
 </string>
           </argument>
         </arguments>

--- a/objects/obj_persistent.object.gmx
+++ b/objects/obj_persistent.object.gmx
@@ -85,89 +85,11 @@ keyboard_set_map(ord('X'),vk_shift)
 //Make the z key do everything the control key does
 keyboard_set_map(ord('Z'),vk_control)
 
-//Handle gamepad support
-if gamepad_is_connected(0)
-    alarm[6] = 1
-
 //Set the epsilon value for floating point numbers
 math_set_epsilon(0.00001)
 
 //Disable application surface automatic drawing
 application_surface_draw_enable(0)
-</string>
-          </argument>
-        </arguments>
-      </action>
-    </event>
-    <event eventtype="2" enumb="6">
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>///Gamepad support
-
-//Up button
-if gamepad_button_check_pressed(0,gp_padu)
-    keyboard_key_press(vk_up)
-else if gamepad_button_check_released(0,gp_padu)
-    keyboard_key_release(vk_up)
-
-//Down button
-if gamepad_button_check_pressed(0,gp_padd)
-    keyboard_key_press(vk_down)
-else if gamepad_button_check_released(0,gp_padd)
-    keyboard_key_release(vk_down)
-
-//Left button
-if gamepad_button_check_pressed(0,gp_padl)
-    keyboard_key_press(vk_left)
-else if gamepad_button_check_released(0,gp_padl)
-    keyboard_key_release(vk_left)
-
-//Right button
-if gamepad_button_check_pressed(0,gp_padr)
-    keyboard_key_press(vk_right)
-else if gamepad_button_check_released(0,gp_padr)
-    keyboard_key_release(vk_right)
-
-//A button
-if gamepad_button_check_pressed(0,gp_face1)
-    keyboard_key_press(vk_shift)
-else if gamepad_button_check_released(0,gp_face1)
-    keyboard_key_release(vk_shift)
-
-//B button
-if gamepad_button_check_pressed(0,gp_face2)
-    keyboard_key_press(vk_control)
-else if gamepad_button_check_released(0,gp_face2)
-    keyboard_key_release(vk_control)
-
-//Start button
-if gamepad_button_check_pressed(0,gp_start)
-    keyboard_key_press(vk_enter)
-else if gamepad_button_check_released(0,gp_start)
-    keyboard_key_release(vk_enter)
-
-//Select button
-if gamepad_button_check_pressed(0,gp_select)
-    keyboard_key_press(vk_space)
-else if gamepad_button_check_released(0,gp_select)
-    keyboard_key_release(vk_space)
-
-//Continue
-alarm[6] = 1
 </string>
           </argument>
         </arguments>
@@ -341,6 +263,82 @@ if not instance_exists(obj_mariostart)
 //Delete the screenshot
 if background_exists(back)
     background_delete(back)
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="3" enumb="0">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///Gamepad support
+
+if gamepad_is_connected(0)
+{
+//Up button
+if gamepad_button_check_pressed(0,gp_padu)
+    keyboard_key_press(vk_up)
+else if gamepad_button_check_released(0,gp_padu)
+    keyboard_key_release(vk_up)
+
+//Down button
+if gamepad_button_check_pressed(0,gp_padd)
+    keyboard_key_press(vk_down)
+else if gamepad_button_check_released(0,gp_padd)
+    keyboard_key_release(vk_down)
+
+//Left button
+if gamepad_button_check_pressed(0,gp_padl)
+    keyboard_key_press(vk_left)
+else if gamepad_button_check_released(0,gp_padl)
+    keyboard_key_release(vk_left)
+
+//Right button
+if gamepad_button_check_pressed(0,gp_padr)
+    keyboard_key_press(vk_right)
+else if gamepad_button_check_released(0,gp_padr)
+    keyboard_key_release(vk_right)
+
+//A button
+if gamepad_button_check_pressed(0,gp_face1)
+    keyboard_key_press(vk_shift)
+else if gamepad_button_check_released(0,gp_face1)
+    keyboard_key_release(vk_shift)
+
+//B/Y button
+if (gamepad_button_check_pressed(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+or (gamepad_button_check_pressed(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_press(vk_control)
+else if (gamepad_button_check_released(0,gp_face2) and not gamepad_button_check(0,gp_face3))
+     or (gamepad_button_check_released(0,gp_face3) and not gamepad_button_check(0,gp_face2))
+    keyboard_key_release(vk_control)
+
+//Start button
+if gamepad_button_check_pressed(0,gp_start)
+    keyboard_key_press(vk_enter)
+else if gamepad_button_check_released(0,gp_start)
+    keyboard_key_release(vk_enter)
+
+//Select button
+if gamepad_button_check_pressed(0,gp_select)
+    keyboard_key_press(vk_space)
+else if gamepad_button_check_released(0,gp_select)
+    keyboard_key_release(vk_space)
+}
 </string>
           </argument>
         </arguments>


### PR DESCRIPTION
Before making this change, I was unable to use my DualShock 4 controller to play this engine.
After this change, I am now fully able to use my DualShock 4 to play. (It might be note-worthy to say I'm using a tool to emulate my DualShock 4 as an XBox controller.)

Additionally, the "control" key has been remapped from B/Circle to both B and X/Circle and Square (XBox/PlayStation), as I personally find it uncomfortable to press both the right and the down "face" buttons at the same time.